### PR TITLE
ValidationAttributes - Refactored The DateTime Validation Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 
-# Rhinobyte.DataAnnotationsValidation
+# Rhinobyte.Validation
+
+Helper libraries for validation.
+
+## Rhinobyte.DataAnnotations
 
 [![NuGet version (Rhinobyte.DataAnnotations)](https://img.shields.io/nuget/v/Rhinobyte.DataAnnotations.svg?style=flat)](https://www.nuget.org/packages/Rhinobyte.DataAnnotations/)
 
-This repository contains the code to build the Rhinobyte.DataAnnotations library for .Net
-
-This library contains types to extend the behavior provided by the `System.ComponentModel.DataAnnotations` types.
+This library contains the code to build the Rhinobyte.DataAnnotations library for .Net.
+It contains types to extend the behavior provided by the `System.ComponentModel.DataAnnotations` types.
 
 ## DateTime Validation Attributes
 

--- a/src/Rhinobyte.DataAnnotations/Rhinobyte.DataAnnotations.csproj
+++ b/src/Rhinobyte.DataAnnotations/Rhinobyte.DataAnnotations.csproj
@@ -3,30 +3,32 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
+        
+        <!-- VERSION VALUES -->
+        <AssemblyVersion>1.0.1.0</AssemblyVersion>
+        <FileVersion>1.0.1.0</FileVersion>
+        <InformationalVersion>1.0.1</InformationalVersion>
+        <PackageVersion>1.0.1</PackageVersion>
+        <Version>1.0.1</Version>
 
         <AssemblyName>Rhinobyte.DataAnnotations</AssemblyName>
-        <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <Authors>Ryan Thomas</Authors>
         <Company>Rhinobyte Software</Company>
         <Copyright>Copyright © Rhinobyte Software $([System.DateTime]::Now.ToString("yyyy"))</Copyright>
         <Description>Provides DataAnnotation extensions for improved validation</Description>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <FileVersion>1.0.0.0</FileVersion>
         <IncludeSymbols>true</IncludeSymbols>
-        <InformationalVersion>1.0.0</InformationalVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <PackageId>Rhinobyte.DataAnnotations</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>dataannotations validation</PackageTags>
-        <PackageVersion>1.0.0</PackageVersion>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>https://github.com/RhinobyteSoftware/DataAnnotations</RepositoryUrl>
+        <RepositoryUrl>https://github.com/RhinobyteSoftware/Validation</RepositoryUrl>
         <RootNamespace>Rhinobyte.DataAnnotations</RootNamespace>
         <Summary>Provides DataAnnotation extensions for improved validation</Summary>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <Title>Rhinobyte.DataAnnotations</Title>
-        <Version>1.0.0</Version>
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/Rhinobyte.DataAnnotations/SqlServerDateTimeAttribute.cs
+++ b/src/Rhinobyte.DataAnnotations/SqlServerDateTimeAttribute.cs
@@ -29,11 +29,9 @@ namespace Rhinobyte.DataAnnotations
 		/// Construct a new SqlServerDateTimeAttribute instance.
 		/// </summary>
 		public SqlServerDateTimeAttribute()
-			: base(ErrorMessageAccessor)
+			: base(errorMessageAccessor: null)
 		{
 		}
-
-		private static string ErrorMessageAccessor() => "The field {0} must be between {1} and {2}.";
 
 		/// <summary>
 		///     Override of <see cref="ValidationAttribute.FormatErrorMessage" />
@@ -41,33 +39,41 @@ namespace Rhinobyte.DataAnnotations
 		/// <param name="name">The user-visible name to include in the formatted message.</param>
 		/// <returns>A localized string describing the minimum and maximum values</returns>
 		/// <remarks>This override exists to provide a formatted message describing the minimum and maximum values</remarks>
-		public override string FormatErrorMessage(string name)
-			=> string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+		public override string FormatErrorMessage(string? name)
+			=> string.Format(CultureInfo.CurrentCulture, "The field {0} must be between {1} and {2}.", name, Minimum, Maximum);
 
 		/// <summary>
-		///		Returns true if the <paramref name="value"/> falls between minimum and maximum, inclusive.
+		///		Returns <see cref="ValidationResult.Success"/> if the <paramref name="value"/> falls between minimum and maximum, inclusive.
 		/// </summary>
 		/// <remarks>
-		///		Returns true for null values. Use the <see cref="RequiredAttribute"/> to assert a value is not empty.
+		///		Returns <see cref="ValidationResult.Success"/> for null values. Use the <see cref="RequiredAttribute"/> to assert a value is not empty.
 		/// </remarks>
 		/// <exception cref="InvalidCastException">Thrown if the <paramref name="value"/> cannot be cast to a <see cref="DateTime"/>.</exception>
-		public override bool IsValid(object? value)
+		protected override ValidationResult IsValid(object? value, ValidationContext? validationContext)
 		{
 			// Automatically pass if value is null or empty. RequiredAttribute should be used to assert a value is not empty.
 			if (value == null)
 			{
-				return true;
+				return ValidationResult.Success;
 			}
 
 			try
 			{
 				var dateTimeValue = (DateTime)value;
-				return Minimum <= dateTimeValue && dateTimeValue <= Maximum;
+				if (Minimum <= dateTimeValue && dateTimeValue <= Maximum)
+				{
+					return ValidationResult.Success;
+				}
+
+				string[]? memberNames = validationContext?.MemberName is { } memberName
+					? new[] { memberName }
+					: null;
+				return new ValidationResult(FormatErrorMessage(validationContext?.DisplayName), memberNames);
 			}
 			catch (InvalidCastException exc)
 			{
-				var castException = new InvalidCastException("The [SqlServerDateTime] attribute must be used on a DateTime member", exc);
-				castException.Data["value"] = value;
+				var castException = new InvalidCastException($@"The [SqlServerDateTime] attribute must be used on a DateTime member. [MemberName: ""{validationContext?.DisplayName}""]", exc);
+				castException.Data["ValidationValue"] = value;
 				throw castException;
 			}
 		}

--- a/src/Rhinobyte.DataAnnotations/SqlServerSmallDateTimeAttribute.cs
+++ b/src/Rhinobyte.DataAnnotations/SqlServerSmallDateTimeAttribute.cs
@@ -29,11 +29,9 @@ namespace Rhinobyte.DataAnnotations
 		/// Construct a new SqlServerSmallDateTimeAttribute instance.
 		/// </summary>
 		public SqlServerSmallDateTimeAttribute()
-			: base(ErrorMessageAccessor)
+			: base(errorMessageAccessor: null)
 		{
 		}
-
-		private static string ErrorMessageAccessor() => "The field {0} must be between {1} and {2}.";
 
 		/// <summary>
 		///     Override of <see cref="ValidationAttribute.FormatErrorMessage" />
@@ -41,33 +39,41 @@ namespace Rhinobyte.DataAnnotations
 		/// <param name="name">The user-visible name to include in the formatted message.</param>
 		/// <returns>A localized string describing the minimum and maximum values</returns>
 		/// <remarks>This override exists to provide a formatted message describing the minimum and maximum values</remarks>
-		public override string FormatErrorMessage(string name)
-			=> string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+		public override string FormatErrorMessage(string? name)
+			=> string.Format(CultureInfo.CurrentCulture, "The field {0} must be between {1} and {2}.", name, Minimum, Maximum);
 
 		/// <summary>
-		///		Returns true if the <paramref name="value"/> falls between minimum and maximum, inclusive.
+		///		Returns <see cref="ValidationResult.Success"/> if the <paramref name="value"/> falls between minimum and maximum, inclusive.
 		/// </summary>
 		/// <remarks>
-		///		Returns true for null values. Use the <see cref="RequiredAttribute"/> to assert a value is not empty.
+		///		Returns <see cref="ValidationResult.Success"/> for null values. Use the <see cref="RequiredAttribute"/> to assert a value is not empty.
 		/// </remarks>
 		/// <exception cref="InvalidCastException">Thrown if the <paramref name="value"/> cannot be cast to a <see cref="DateTime"/>.</exception>
-		public override bool IsValid(object? value)
+		protected override ValidationResult IsValid(object? value, ValidationContext? validationContext)
 		{
 			// Automatically pass if value is null or empty. RequiredAttribute should be used to assert a value is not empty.
 			if (value == null)
 			{
-				return true;
+				return ValidationResult.Success;
 			}
 
 			try
 			{
 				var dateTimeValue = (DateTime)value;
-				return Minimum <= dateTimeValue && dateTimeValue <= Maximum;
+				if (Minimum <= dateTimeValue && dateTimeValue <= Maximum)
+				{
+					return ValidationResult.Success;
+				}
+
+				string[]? memberNames = validationContext?.MemberName is { } memberName
+					? new[] { memberName }
+					: null;
+				return new ValidationResult(FormatErrorMessage(validationContext?.DisplayName), memberNames);
 			}
 			catch (InvalidCastException exc)
 			{
-				var castException = new InvalidCastException("The [SqlServerSmallDateTime] attribute must be used on a DateTime member", exc);
-				castException.Data["value"] = value;
+				var castException = new InvalidCastException($@"The [SqlServerSmallDateTime] attribute must be used on a DateTime member. [MemberName: ""{validationContext?.DisplayName}""]", exc);
+				castException.Data["ValidationValue"] = value;
 				throw castException;
 			}
 		}

--- a/tests/Rhinobyte.DataAnnotations.UnitTests/DateTimeRangeAttributeUnitTests.cs
+++ b/tests/Rhinobyte.DataAnnotations.UnitTests/DateTimeRangeAttributeUnitTests.cs
@@ -26,33 +26,34 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 		[DataTestMethod]
 		[DataRow("SomeProperty", "1900-01-01", "invalid")]
 		[DataRow("DateEntered", "blue", "1999-12-31")]
+		public void DateTimeRangeAttribute_FormattedErrorMessage_throws_format_excpetion_when_the_attribute_parameters_are_invalid(string memberName, string minimum, string maximum)
+		{
+			Invoking(() => new DateTimeRangeAttribute(minimum, maximum).FormatErrorMessage(memberName))
+				.Should()
+				.Throw<FormatException>()
+				.WithMessage($@"The [DateTimeRange] attribute minimum/maximum parameters must be valid datetime strings. [MemberName: ""{memberName}""]");
+		}
+
+		[TestMethod]
+		public void DateTimeRangeAttribute_FormattedErrorMessage_throws_invalid_operation_exception_if_the_minimum_is_greater_than_the_maximum()
+		{
+			Invoking(() => new DateTimeRangeAttribute("2001-01-01", "1900-01-01").FormatErrorMessage("MinimumGreaterThanMaximum"))
+				.Should()
+				.Throw<InvalidOperationException>()
+				.WithMessage(@"[DateTimeRange] attribute minimum must be less than or equal to the maximum. [MemberName: ""MinimumGreaterThanMaximum""]");
+		}
+
+		[DataTestMethod]
 		[DataRow("EnteredOn", "", "1999-12-31")]
 		[DataRow("EnteredOn", "1900-01-01", "")]
 		[DataRow("BirthDate", null, "1999-12-31")]
 		[DataRow("Something", "-500-01-01", null)]
-		[DataRow("MinimumGreaterThanMaximum", "1999-01-01", "1900-01-01")]
-		public void DateTimeRangeAttribute_FormattedErrorMessage_throws_when_the_attribute_parameters_are_invalid(string memberName, string minimum, string maximum)
+		public void DateTimeRangeAttribute_FormattedErrorMessage_throws_invalid_operation_exception_when_the_attribute_parameters_are_null_or_empty(string memberName, string minimum, string maximum)
 		{
 			Invoking(() => new DateTimeRangeAttribute(minimum, maximum).FormatErrorMessage(memberName))
 				.Should()
 				.Throw<InvalidOperationException>()
-				.WithMessage($@"[DateTimeRange] attribute minimum/maximum are missing or invalid. [FieldName: ""{memberName}""]");
-		}
-
-
-
-		[DataTestMethod]
-		[DataRow("1900-01-01", "invalid")]
-		[DataRow("blue", "1999-12-31")]
-		[DataRow("", "1999-12-31")]
-		[DataRow("1900-01-01", "")]
-		[DataRow(null, "1999-12-31")]
-		[DataRow("-500-01-01", null)]
-		[DataRow("1999-01-01", "1900-01-01")]
-		public void DateTimeRangeAttribute_IsValid_returns_false_when_the_attribute_parameters_are_invalid(string minimum, string maximum)
-		{
-			var dateTimeRangeAttribute = new DateTimeRangeAttribute(minimum, maximum);
-			dateTimeRangeAttribute.IsValid(DateTime.Today).Should().Be(false);
+				.WithMessage($@"[DateTimeRange] attribute minimum/maximum are required. [MemberName: ""{memberName}""]");
 		}
 
 		[DataTestMethod]
@@ -92,7 +93,40 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 			Invoking(() => dateTimeRangeAttribute.IsValid(value))
 				.Should()
 				.Throw<InvalidCastException>()
-				.WithMessage("The [DateTimeRange] attribute must be used on a DateTime member");
+				.WithMessage(@"The [DateTimeRange] attribute must be used on a DateTime member. [MemberName: """"]");
+		}
+
+		[TestMethod]
+		public void DateTimeRangeAttribute_IsValid_throws_if_the_minimum_is_greater_than_the_maximum()
+		{
+			Invoking(() => new DateTimeRangeAttribute("2001-01-01", "1900-01-01").IsValid(DateTime.Today))
+				.Should()
+				.Throw<InvalidOperationException>()
+				.WithMessage(@"[DateTimeRange] attribute minimum must be less than or equal to the maximum. [MemberName: """"]");
+		}
+
+		[DataTestMethod]
+		[DataRow("1900-01-01", "invalid")]
+		[DataRow("blue", "1999-12-31")]
+		public void DateTimeRangeAttribute_IsValid_throws_when_the_attribute_parameters_are_invalid(string minimum, string maximum)
+		{
+			Invoking(() => new DateTimeRangeAttribute(minimum, maximum).IsValid(DateTime.Today))
+				.Should()
+				.Throw<FormatException>()
+				.WithMessage(@"The [DateTimeRange] attribute minimum/maximum parameters must be valid datetime strings. [MemberName: """"]");
+		}
+
+		[DataTestMethod]
+		[DataRow("", "1999-12-31")]
+		[DataRow("1900-01-01", "")]
+		[DataRow(null, "1999-12-31")]
+		[DataRow("-500-01-01", null)]
+		public void DateTimeRangeAttribute_IsValid_throws_when_the_attribute_parameters_are_null_or_empty(string minimum, string maximum)
+		{
+			Invoking(() => new DateTimeRangeAttribute(minimum, maximum).IsValid(DateTime.Today))
+				.Should()
+				.Throw<InvalidOperationException>()
+				.WithMessage(@"[DateTimeRange] attribute minimum/maximum are required. [MemberName: """"]");
 		}
 	}
 }

--- a/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerDateAttributeUnitTests.cs
+++ b/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerDateAttributeUnitTests.cs
@@ -59,7 +59,7 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 			Invoking(() => sqlServerDateAttribute.IsValid(value))
 				.Should()
 				.Throw<InvalidCastException>()
-				.WithMessage("The [SqlServerDate] attribute must be used on a DateTime member");
+				.WithMessage(@"The [SqlServerDate] attribute must be used on a DateTime member. [MemberName: """"]");
 		}
 	}
 }

--- a/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerDateTimeAttributeUnitTests.cs
+++ b/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerDateTimeAttributeUnitTests.cs
@@ -58,7 +58,7 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 			Invoking(() => sqlServerDateTimeAttribute.IsValid(value))
 				.Should()
 				.Throw<InvalidCastException>()
-				.WithMessage("The [SqlServerDateTime] attribute must be used on a DateTime member");
+				.WithMessage(@"The [SqlServerDateTime] attribute must be used on a DateTime member. [MemberName: """"]");
 		}
 	}
 }

--- a/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerSmallDateTimeAttributeUnitTests.cs
+++ b/tests/Rhinobyte.DataAnnotations.UnitTests/SqlServerSmallDateTimeAttributeUnitTests.cs
@@ -61,7 +61,7 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 			Invoking(() => sqlServerSmallDateTimeAttribute.IsValid(value))
 				.Should()
 				.Throw<InvalidCastException>()
-				.WithMessage("The [SqlServerSmallDateTime] attribute must be used on a DateTime member");
+				.WithMessage(@"The [SqlServerSmallDateTime] attribute must be used on a DateTime member. [MemberName: """"]");
 		}
 	}
 }

--- a/tests/Rhinobyte.DataAnnotations.UnitTests/ValidatorUnitTests.cs
+++ b/tests/Rhinobyte.DataAnnotations.UnitTests/ValidatorUnitTests.cs
@@ -337,7 +337,7 @@ namespace Rhinobyte.DataAnnotations.UnitTests
 			Invoking(() => Validator.TryValidateObject(modelToValidate, validationContext, validationResults, true))
 				.Should()
 				.Throw<InvalidCastException>()
-				.WithMessage("The [*] attribute must be used on a DateTime member");
+				.WithMessage("The [*] attribute must be used on a DateTime member. [MemberName: *]");
 		}
 
 		public class DateTimeRangeAttributeModel


### PR DESCRIPTION
* Refactored `DateTimeRangeAttribute`, `SqlServerDateAttribute`, `SqlServerDateTimeAttribute` and `SqlServerSmallDateTimeAttribute` to override the protected `IsValid(object, ValidationContext)` method instead of the public legacy method. 
* Updated `DateTimeRangeAttribute` to delay parsing the date time values until the attribute is actually used.
* Updated the automated unit test cases to account for changes to the exception type/messages thrown.